### PR TITLE
Pass empty string to `body_path` if `changes-file` is empty

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,9 @@
+## 0.0.5
+
+- Trying to do an actual release with `changes-file` set to an empty string caused the
+  `softprops/action-gh-release` action to fail with an error like
+  `EISDIR: illegal operation on a directory, read`. Fixed by @xen (yksen). GH PR #6. Fixes GH #7.
+
 ## 0.0.4 - 2024-12-08
 
 - The `changes-file` parameter can be set to an empty string. If you do this, then the action will

--- a/action.yml
+++ b/action.yml
@@ -127,5 +127,5 @@ runs:
         draft: true
         # The trailing "*" should pick up the checksum file.
         files: ${{ inputs.working-directory }}/${{ steps.package-archive.outputs.archive-basename }}*
-        body_path: ${{ inputs.working-directory }}/${{ inputs.changes-file }}
+        body_path: ${{ ( inputs.changes-file && format( '{0}/{1}', inputs.working-directory, inputs.changes-file ) ) || '' }}
       if: github.ref_type == 'tag' && startsWith( github.ref_name, inputs.release-tag-prefix )


### PR DESCRIPTION
Hi, the problem is related to #5. Basically when `inputs.changes-file` variable is empty then `body_path` for `softprops/action-gh-release` is set to `inputs.working-directory` which results in an `Error: EISDIR: illegal operation on a directory, read` trying to read a directory.

[Failing job example](https://github.com/yksen/harmony/actions/runs/12917640359/job/36024458399)
```
...
changes-file = 
...
Run softprops/action-gh-release@v2
  with:
    body_path: ./
...
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v0.2.1: Error: EISDIR: illegal operation on a directory, read
Error: EISDIR: illegal operation on a directory, read
```

---

Passing an empty string to `body_path` solves the issue.